### PR TITLE
Issue 137

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -24,9 +24,9 @@
           - unzip
       when: full_deploy
 
-- include: firewall.yml
+- import_playbook: firewall.yml
   when: full_deploy
-- include: docker.yml
+- import_playbook: docker.yml
   when: full_deploy
-- include: beryllium.yml
-- include: fail2ban.yml
+- import_playbook: beryllium.yml
+- import_playbook: fail2ban.yml

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -29,3 +29,4 @@
 - include: docker.yml
   when: full_deploy
 - include: beryllium.yml
+- include: fail2ban.yml

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -18,7 +18,9 @@
       shell: curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 
     - name: Add docker repository
-      shell: add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+      ansible.builtin.apt_repository:
+        repo: "deb [arch={{ansible_architecture}}] https://download.docker.com/linux/ubuntu {{ansible_distribution_release}} stable"
+        state: present
 
     - name: install packages (2)
       apt:

--- a/ansible/fail2ban.yml
+++ b/ansible/fail2ban.yml
@@ -1,0 +1,21 @@
+---
+- name: logwatch
+  hosts: all
+  become: yes
+  become_user: root
+
+  tasks:
+
+    - name: Install fail2ban
+      apt: package=fail2ban state=present
+
+    - name: Copy fail2ban default config
+      template: src=templates/fail2ban.conf.j2 dest=/etc/fail2ban/jail.local
+      notify:
+        - restart fail2ban
+
+  handlers:
+
+    - name: restart fail2ban
+      service: name=fail2ban state=restarted
+      

--- a/ansible/fail2ban.yml
+++ b/ansible/fail2ban.yml
@@ -3,6 +3,8 @@
   hosts: all
   become: yes
   become_user: root
+  vars_files:
+    - vars/external_vars.yml
 
   tasks:
 

--- a/ansible/templates/fail2ban.conf.j2
+++ b/ansible/templates/fail2ban.conf.j2
@@ -57,7 +57,7 @@ maxretry = 6
 
 enabled = true
 port = 987
-filter   = sshd-ddos
+filter   = sshd
 logpath  = /var/log/auth.log
 maxretry = 6
 

--- a/ansible/templates/fail2ban.conf.j2
+++ b/ansible/templates/fail2ban.conf.j2
@@ -1,0 +1,69 @@
+# Fail2Ban configuration file.
+#
+
+# to view current bans, run one of the following:
+# fail2ban-client status ssh
+# iptables --list -n | fgrep DROP
+
+# The DEFAULT allows a global definition of the options. They can be overridden
+# in each jail afterwards.
+
+[DEFAULT]
+
+ignoreip = 127.0.0.1
+bantime  = 3600
+findtime = 3600
+maxretry = 3
+backend = auto
+usedns = warn
+destemail = {{ ADMIN_EMAIL }}
+
+#
+# ACTIONS
+#
+
+banaction = iptables-multiport
+mta = sendmail
+protocol = tcp
+chain = INPUT
+
+#
+# Action shortcuts. To be used to define action parameter
+
+# The simplest action to take: ban only
+action_ = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+
+# ban & send an e-mail with whois report to the destemail.
+action_mw = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+              %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s"]
+
+# ban & send an e-mail with whois report and relevant log lines
+# to the destemail.
+action_mwl = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+               %(mta)s-whois-lines[name=%(__name__)s, dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+
+# default action
+action = %(action_mw)s
+
+[ssh]
+
+enabled  = true
+port = 987
+filter   = sshd
+logpath  = /var/log/auth.log
+maxretry = 6
+
+[ssh-ddos]
+
+enabled = true
+port = 987
+filter   = sshd-ddos
+logpath  = /var/log/auth.log
+maxretry = 6
+
+[nginx-http-auth]
+
+enabled = true
+filter   = nginx-http-auth
+port     = http,https
+logpath  = /var/log/nginx/error.log

--- a/ansible/vars/external_vars.yml
+++ b/ansible/vars/external_vars.yml
@@ -1,0 +1,2 @@
+---
+ADMIN_EMAIL: admin@zap.me

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       - ./web/nginx:/etc/nginx/templates
       - ./web/alloy:/etc/nginx/alloy
       - ./web/certbot/conf:/etc/letsencrypt
+      - /var/log/nginx:/var/log/nginx
 
   bitcoind:
     image: btcpayserver/bitcoin:22.0


### PR DESCRIPTION
- fix the playbook from running because of deprecated commands
- mount the be_web /var/log/nginx dir to the host /var/log/nginx dir
- add fail2ban
  - the default filters should be running
  - additional filters may need to be added as we go along.

NOTE:
fail2ban not running correctly because of the nginx dir not existing in beryllium-test. the directory/file will exists when this is merged with the master and deployed from the master.
