### PR TITLE
Fix an issue with the tables where it appears that the metadata has t…

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -71,6 +71,7 @@ class OfAssetMixin():
 
 roles_users = Table(
     'roles_users',
+    BaseModel.metadata,
     Column('user_id', Integer(), ForeignKey('user.id')), # pyright: ignore [reportGeneralTypeIssues]
     Column('role_id', Integer(), ForeignKey('role.id'))
 )
@@ -202,6 +203,7 @@ class UserUpdateEmailRequest(BaseModel, FromTokenMixin):
 
 permissions_api_keys = Table(
     'permissions_api_keys',
+    BaseModel.metadata,
     Column('api_key_id', Integer(), ForeignKey('api_key.id')), # pyright: ignore [reportGeneralTypeIssues]
     Column('permission_id', Integer(), ForeignKey('permission.id'))
 )


### PR DESCRIPTION
…o be defined.

https://stackoverflow.com/questions/29269695/python-sqlalchemy-attributeerror-neither-column-object-nor-comparator-obje


From what i could tell this affects the ones with the many-to-many relationship ie.
- user_roles
- permissions_api_keys

not sure why this is happening now, because the answer appears to be old