### PR TITLE
fix mail server hostname

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,13 +145,13 @@ services:
   mail:
     container_name: mail
     environment:
-      ALLOWED_SENDER_DOMAINS: beryllium-test.zap.me
-      HOSTNAME: mail
+      ALLOWED_SENDER_DOMAINS: ${EMAIL_SENDER} ${SERVER_NAME}
+      HOSTNAME: ${SERVER_NAME:?SERVER_NAME unset}
     image: boky/postfix
     expose:
       - "587"
     volumes:
-    - ./host/keys:/etc/opendkim/keys
+    - ./web/dkim/keys:/etc/opendkim/keys
 
 volumes:
   pgdata:


### PR DESCRIPTION
- mail ALLOWED_SENDER_DOMAINS should not be hardcoded (otherwise it wont work on other servers like beryllium.bitforge.me)
- set mail:HOSTNAME and mail:ALLOWED_SENDER_DOMAINS to SERVER_NAME


fixes most of the mail-sender.com reported issues (https://www.mail-tester.com/test-s9mijlzan&reloaded=1) and fixes emailing to gmail too