### PR TITLE
update to latest nginix-certbox image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - "5000"
 
   web:
-    image: jonasal/nginx-certbot:2.4.1-nginx1.21.3-alpine
+    image: jonasal/nginx-certbot:3.2.0-nginx1.23.1-alpine
     container_name: be_web
     restart: unless-stopped
     environment:


### PR DESCRIPTION
was trying to fix an issue with berylium-test not renewing its certificate. this didnt seem to fix the problem but it is probably good to do anyhow