### PR TITLE
override is_editable to make flask-admin columns editable again

### DIFF
--- a/src/admin.py
+++ b/src/admin.py
@@ -357,6 +357,13 @@ class BaseModelView(sqla.ModelView):
             return redirect(url_for('security.login', next=request.url))
         return None
 
+    def is_editable(self, name):
+        """
+        Override builtin so we can use the pre Oct-2021 behaviour of having editable
+        columns without having the entire table editable
+        """
+        return name in self.column_editable_list
+
 class RestrictedModelView(BaseModelView):
     can_create = False
     can_delete = False

--- a/src/api_endpoint.py
+++ b/src/api_endpoint.py
@@ -174,7 +174,7 @@ def api_key_create():
     api_key = ApiKey(user, device_name)
     for name in Permission.PERMS_ALL:
         perm = Permission.from_name(db.session, name)
-        assert(perm)
+        assert perm
         api_key.permissions.append(perm)
     db.session.add(api_key)
     db.session.commit()


### PR DESCRIPTION
https://github.com/zap-me/ops/issues/174