### PR TITLE
separate out supplemental api routes so that we can apply CSRF restrictions to them

### DIFF
--- a/src/api_endpoint.py
+++ b/src/api_endpoint.py
@@ -33,6 +33,10 @@ api = Blueprint('api', __name__, template_folder='templates')
 limiter.limit('100/minute')(api)
 csrf.exempt(api)
 
+# blueprint for supplemental routes of the api (like user confirmations etc), we separate this out so it have CSRF restrictions applied etc
+api_supplemental = Blueprint('api_supplemental', __name__, template_folder='templates')
+limiter.limit('100/minute')(api_supplemental)
+
 def _user_subaccount_get_or_create(db_session, user):
     # create subaccount for user
     if not user.dasset_subaccount:
@@ -94,7 +98,7 @@ def user_register():
     db.session.commit()
     return 'ok'
 
-@api.route('/user_registration_confirm/<token>', methods=['GET'])
+@api_supplemental.route('/user_registration_confirm/<token>', methods=['GET'])
 @limiter.limit('20/minute')
 def user_registration_confirm(token=None):
     if not token:
@@ -227,7 +231,7 @@ def api_key_claim():
     db.session.commit()
     return jsonify(dict(token=api_key.token, secret=api_key.secret, device_name=api_key.device_name, expiry=api_key.expiry))
 
-@api.route('/api_key_confirm/<token>/<secret>', methods=['GET', 'POST'])
+@api_supplemental.route('/api_key_confirm/<token>/<secret>', methods=['GET', 'POST'])
 @limiter.limit('20/minute')
 def api_key_confirm(token=None, secret=None):
     if not token or not secret:
@@ -323,7 +327,7 @@ def user_update_email():
     tf_code_send(api_key.user)
     return 'ok'
 
-@api.route('/user_update_email_confirm/<token>', methods=['GET', 'POST'])
+@api_supplemental.route('/user_update_email_confirm/<token>', methods=['GET', 'POST'])
 @limiter.limit('10/hour')
 def user_update_email_confirm(token=None):
     if not token:
@@ -538,7 +542,7 @@ def _validate_crypto_asset_deposit(asset: str, l2_network: str | None):
         return bad_request(web_utils.INVALID_NETWORK)
     return None
 
-@api.route('/withdrawal_confirm/<token>/<secret>', methods=['GET', 'POST'])
+@api_supplemental.route('/withdrawal_confirm/<token>/<secret>', methods=['GET', 'POST'])
 @limiter.limit('20/minute')
 def withdrawal_confirm(token=None, secret=None):
     if not token or not secret:

--- a/src/email_utils.py
+++ b/src/email_utils.py
@@ -58,17 +58,17 @@ def email_exception(logger: Logger, msg: str):
     send_email("beryllium exception", msg)
 
 def email_user_create_request(logger: Logger, req: UserCreateRequest):
-    url = url_for("api.user_registration_confirm", token=req.token, _external=True)
+    url = url_for("api_supplemental.user_registration_confirm", token=req.token, _external=True)
     msg = f"You have a pending user registration waiting!<br/><br/>Confirm your registration <a href='{url}'>here</a><br/><br/>Confirm within {req.MINUTES_EXPIRY} minutes"
     send_email("Confirm your registration", msg, req.email)
 
 def email_user_update_email_request(logger: Logger, req: UserUpdateEmailRequest):
-    url = url_for("api.user_update_email_confirm", token=req.token, _external=True)
+    url = url_for("api_supplemental.user_update_email_confirm", token=req.token, _external=True)
     msg = f"You have a pending update email request waiting!<br/><br/>Confirm your new email <a href='{url}'>here</a><br/><br/>Confirm within {req.MINUTES_EXPIRY} minutes"
     send_email("Confirm your update email request", msg, req.email)
 
 def email_api_key_request(logger: Logger, req: ApiKeyRequest):
-    url = url_for("api.api_key_confirm", token=req.token, secret=req.secret, _external=True)
+    url = url_for("api_supplemental.api_key_confirm", token=req.token, secret=req.secret, _external=True)
     msg = f"You have a pending email login request waiting!<br/><br/>Confirm your email login <a href='{url}'>here</a><br/><br/>Confirm within {req.MINUTES_EXPIRY} minutes"
     send_email("Confirm your email login request", msg, req.user.email)
 
@@ -111,7 +111,7 @@ def email_tripwire_notification(logger: Logger):
     send_email(subject, html_content)
 
 def email_withdrawal_confirmation(logger: Logger, conf: WithdrawalConfirmation):
-    url = url_for("api.withdrawal_confirm", token=conf.token, secret=conf.secret, _external=True)
+    url = url_for("api_supplemental.withdrawal_confirm", token=conf.token, secret=conf.secret, _external=True)
     assert conf.withdrawal
     asset = conf.withdrawal.asset
     amount_dec = assets.asset_int_to_dec(asset, conf.withdrawal.amount)

--- a/src/static/assets/js_custom/confirmation_result.js
+++ b/src/static/assets/js_custom/confirmation_result.js
@@ -1,0 +1,8 @@
+$(document).ready(function() {
+    $('#close').click(function() {
+        // 'window.close()' will not work unless JS created the window
+        // so we do it this way to allow us to close this window
+        open(location, '_self').close();
+        return false;
+    });
+});

--- a/src/templates/api/api_key_confirm.html
+++ b/src/templates/api/api_key_confirm.html
@@ -1,3 +1,4 @@
+{% set no_login = True %}
 {% extends "layout.html" %}
 {% block content %}
     <div class="row justify-content-center">

--- a/src/templates/api/api_key_confirm.html
+++ b/src/templates/api/api_key_confirm.html
@@ -6,6 +6,10 @@
                 <div class="card-body">
                     <h5 class="card-title">Email Login Request</h5>
                     <form method="POST">
+                        <input type="hidden"
+                               id="csrfToken"
+                               name="csrf_token"
+                               value="{{ csrf_token() }}"/>
                         <h6>Device Name:</h6>
                         <span>{{ req.device_name | e }}</span>
                         <!-- not using permissions

--- a/src/templates/api/confirmation_result.html
+++ b/src/templates/api/confirmation_result.html
@@ -1,0 +1,19 @@
+{% set no_login = True %}
+{% extends "layout.html" %}
+{% block content %}
+    <div class="row">
+        <div class="col-12">
+            <div class="d-flex justify-content-center">
+                <div class="card">
+                    <div class="card-body">
+                        <p>You can now close this window and go back to the app.</p>
+                        <button type="submit" class="btn btn-primary" id="close">Close</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+{% block scripts %}
+    <script src="{{ url_for('static',filename='assets/js_custom/confirmation_result.js') }}"></script>
+{% endblock %}

--- a/src/templates/api/update_email_confirm.html
+++ b/src/templates/api/update_email_confirm.html
@@ -6,6 +6,10 @@
                 <div class="card-body">
                     <h5 class="card-title">Update Email Request</h5>
                     <form method="POST">
+                        <input type="hidden"
+                               id="csrfToken"
+                               name="csrf_token"
+                               value="{{ csrf_token() }}"/>
                         <h6>Old Email:</h6>
                         <span>{{ req.user.email | e }}</span>
                         <br/>

--- a/src/templates/api/update_email_confirm.html
+++ b/src/templates/api/update_email_confirm.html
@@ -1,3 +1,4 @@
+{% set no_login = True %}
 {% extends "layout.html" %}
 {% block content %}
     <div class="row justify-content-center">

--- a/src/templates/api/withdrawal_confirm.html
+++ b/src/templates/api/withdrawal_confirm.html
@@ -1,3 +1,4 @@
+{% set no_login = True %}
 {% extends "layout.html" %}
 {% block content %}
     <div class="row justify-content-center">

--- a/src/templates/api/withdrawal_confirm.html
+++ b/src/templates/api/withdrawal_confirm.html
@@ -6,6 +6,10 @@
                 <div class="card-body">
                     <h4 class="card-title">Withdrawal Confirmation</h4>
                     <form method="POST">
+                        <input type="hidden"
+                               id="csrfToken"
+                               name="csrf_token"
+                               value="{{ csrf_token() }}"/>
                         <h5>Recipient:</h5>
                         <span><pre>{{ conf.withdrawal.recipient }}</pre></span>
                         <h5>Amount:</h5>

--- a/src/templates/email_layout.html
+++ b/src/templates/email_layout.html
@@ -126,8 +126,8 @@
                             <div class="logo">
                                 <img class="image_fix"
                                      src="{{ config['LOGO_EMAIL_SRC'] }}"
-                                     alt="beryllium logo"
-                                     title="beryllium logo"
+                                     alt="bitforge logo"
+                                     title="bitforge logo"
                                      width="30"/>
                             </div>
                         </td>

--- a/src/templates/layout.html
+++ b/src/templates/layout.html
@@ -66,10 +66,12 @@
                 &nbsp;
             </span>
             <span class="form-inline">
-                {% if current_user.is_authenticated %}
-                    <button class="btn btn-primary" type="button" id="btn-logout"/>Logout</button>
-                {% else %}
-                    <button class="btn btn-primary" type="button" id="btn-login"/>Login</button>
+                {% if no_login != True %}
+                    {% if current_user.is_authenticated %}
+                        <button class="btn btn-primary" type="button" id="btn-logout"/>Logout</button>
+                    {% else %}
+                        <button class="btn btn-primary" type="button" id="btn-login"/>Login</button>
+                    {% endif %}
                 {% endif %}
             </span>
         </div>
@@ -88,7 +90,7 @@
     <div id="navigation" class="container-sm">
         {% block navigation %}{% endblock %}
     </div>
-    <div id="content" class="container-sm m-2">
+    <div id="content" class="container-sm mt-2">
         {% block content %}{% endblock %}
     </div>
     <div id="footer" class="container">

--- a/src/web.py
+++ b/src/web.py
@@ -18,7 +18,7 @@ from fcm import FCM
 from web_utils import bad_request, get_json_params, get_json_params_optional
 import broker
 import depwith
-from api_endpoint import api
+from api_endpoint import api, api_supplemental
 from reward_endpoint import reward
 from reporting_endpoint import reporting
 from payments_endpoint import payments
@@ -57,6 +57,7 @@ fcm = FCM(app.config["FIREBASE_CREDENTIALS"])
 
 # blueprints
 app.register_blueprint(api, url_prefix='/apiv1')
+app.register_blueprint(api_supplemental, url_prefix='/apis')
 app.register_blueprint(reward, url_prefix='/reward')
 app.register_blueprint(reporting, url_prefix='/reporting')
 app.register_blueprint(payments, url_prefix='/payments')


### PR DESCRIPTION
 - Also fix the issue that when we confirm user actions via email link the user can be confused as to what to do after confirming.
 - Also bonus commit 'fix alt image text in emails'