### PR TITLE
mail container doesn't start when host is restarted

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,7 @@ services:
 
   mail:
     container_name: mail
+    restart: unless-stopped
     environment:
       ALLOWED_SENDER_DOMAINS: ${EMAIL_SENDER} ${SERVER_NAME}
       HOSTNAME: ${SERVER_NAME:?SERVER_NAME unset}


### PR DESCRIPTION
noticed that the mail container doesn't restart when the host is restarted. and to start it, need to run 
```
docker-compose run -d
```

edited the docker-compose.yml file to add
```
    restart: unless-stopped
```

so it always restart when the host goes down or something, unless someone stops it.