### PR TITLE
fix rounding when converting decimal to integer

### DIFF
--- a/src/assets.py
+++ b/src/assets.py
@@ -143,7 +143,7 @@ def asset_int_to_dec(asset: str, value: int) -> Dec:
 
 def asset_dec_to_int(asset: str, value: Dec) -> int:
     decimals = asset_decimals(asset)
-    return int(value * Dec(10**decimals))
+    return int(round(value * Dec(10**decimals)))
 
 def asset_dec_to_str(asset: str, value: Dec) -> str:
     decimals = asset_decimals(asset)


### PR DESCRIPTION
if we have a quote like: `quote BID 0.0008955 BTC for 9.9997750000 NZD`

then the integer amounts should be `89550 sats` and `1000 cents` (**not** 999 cents)