### PR TITLE
create withdrawal lock files to halt withdrawal processing if there was an error in the process

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     volumes:
       - "lightning_datadir:/etc/lightning"
       - "bitcoin_datadir:/etc/bitcoin"
+      - ./lockfiles:/app/lockfiles
     links:
       - lightningd
       - db

--- a/src/email_utils.py
+++ b/src/email_utils.py
@@ -56,6 +56,9 @@ def send_email_postfix(logger: Logger, subject: str, msg: str, recipient: str, a
 def email_exception(msg: str):
     send_email("beryllium exception", msg)
 
+def email_catastrophic_error(msg: str):
+    send_email("beryllium catastrophic error", msg)
+
 def email_user_create_request(req: UserCreateRequest):
     url = url_for("api_supplemental.user_registration_confirm", token=req.token, _external=True)
     msg = f"You have a pending user registration waiting!<br/><br/>Confirm your registration <a href='{url}'>here</a><br/><br/>Confirm within {req.MINUTES_EXPIRY} minutes"

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,6 @@
 import re
 import io
+import pathlib
 import decimal
 import base64
 import secrets
@@ -55,3 +56,23 @@ def yield_gevent():
     # using a value of 0 means that this greenlet could be reschedualed again immediately so
     # we sleep for a small positive value to ensure another greenlet gets schedualed
     gevent.sleep(0.001)
+
+_LOCK_FILE_DIR = pathlib.Path('./lockfiles')
+
+def lock_file_exists_any():
+    return any(_LOCK_FILE_DIR.iterdir())
+
+def lock_file_create(filename):
+    _LOCK_FILE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _LOCK_FILE_DIR.joinpath(filename)
+    if path.exists():
+        return False
+    path.touch()
+    return True
+
+def lock_file_remove(filename):
+    path = _LOCK_FILE_DIR.joinpath(filename)
+    if path.exists():
+        path.unlink()
+        return True
+    return False


### PR DESCRIPTION
When processing withdrawals there is a potential mismatch in state between the DB and the BTC wallet. Take the following example:

```
1. start withdrawal process (check balances etc)
2. make withdrawal via BTC wallet
3. set state to COMPLETED in DB
```

This is fine normally but what if the following happens:

```
1. start withdrawal process
2. make withdrawal via BTC wallet
3. critical EXECPTION occurs!

_five minutes passes_

1. start withdrawal process
2. make withdrawal via BTC wallet
3. critical EXECPTION occurs!
```

As you can see if there is an error in the process we could end up endlessly [over]paying the withdrawal. This PR changes the process to:

```
1. start withdrawal process
2. create LOCKFILE for withdrawal (important! exit and log error if lockfile already exists)
3. make withdrawal via BTC wallet
4. set state to COMPLETED in DB
5. remove LOCKFILE for withdrawal
```

If there is an error in the process the lockfile will stop overpayment and an admin will need to come and a) set the withdrawal to completed if it was completed and b) fix the error
