### PR TITLE
remove our port 80-443 redirector in favor of the inbuilt one 

### DIFF
--- a/web/nginx/app.conf.template
+++ b/web/nginx/app.conf.template
@@ -1,16 +1,3 @@
-server {
-  listen 80;
-  server_name $SERVER_NAME;
-
-  location / {
-    return 307 https://$host$request_uri;
-  }
-
-  location /.well-known/acme-challenge/ {
-    root /var/www/certbot;
-  }
-}
-
 server {  
   listen 443 ssl;
   server_name $SERVER_NAME;


### PR DESCRIPTION
the nginx-certbox image has its own redirector which does not use a directory based webroot but instead redirects to a certbot internal server

https://github.com/JonasAlfredsson/docker-nginx-certbot/blob/master/src/nginx_conf.d/redirector.conf