### PR TITLE
add fee breakdown to broker order model

### DIFF
--- a/migrations/versions/e98e2b8329fc_broker_order_fees.py
+++ b/migrations/versions/e98e2b8329fc_broker_order_fees.py
@@ -1,0 +1,26 @@
+"""broker order fees
+
+Revision ID: e98e2b8329fc
+Revises: 9131b7c1162b
+Create Date: 2022-10-26 03:16:53.134344
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e98e2b8329fc'
+down_revision = '9131b7c1162b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('broker_order', sa.Column('quote_fee', sa.BigInteger(), nullable=True))
+    op.add_column('broker_order', sa.Column('quote_fee_fixed', sa.BigInteger(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('broker_order', 'quote_fee_fixed')
+    op.drop_column('broker_order', 'quote_fee')

--- a/src/broker.py
+++ b/src/broker.py
@@ -73,9 +73,11 @@ def order_validate(db_session: Session, user: User, market: str, side: assets.Ma
     logger.info('quote %s %s %s for %s %s, fee: %s %s, fixed fee: %s %s', side.name, amount_dec, base_asset, quote.amountQuoteAsset, quote_asset, quote.feeQuoteAsset, quote_asset, quote.fixedFeeQuoteAsset, quote_asset)
     base_amount = assets.asset_dec_to_int(base_asset, amount_dec)
     quote_amount = assets.asset_dec_to_int(quote_asset, quote.amountQuoteAsset)
+    quote_fee_amount = assets.asset_dec_to_int(quote_asset, quote.feeQuoteAsset)
+    quote_fee_fixed_amount = assets.asset_dec_to_int(quote_asset, quote.fixedFeeQuoteAsset)
     if base_amount <= 0 or quote_amount <= 0:
         return web_utils.AMOUNT_TOO_LOW, None
-    order = BrokerOrder(user, market, side.value, base_asset, quote_asset, base_amount, quote_amount)
+    order = BrokerOrder(user, market, side.value, base_asset, quote_asset, base_amount, quote_amount, quote_fee_amount, quote_fee_fixed_amount)
     err_msg = order_check_funds(db_session, order)
     if err_msg:
         return err_msg, None


### PR DESCRIPTION
This give extra info so the UI can give a fee breakdown.

New example response from `broker_order_validate/create` API:

```
{
  "broker_order": {
    "base_amount": 10354, 
    "base_amount_dec": "0.00010354", 
    "base_asset": "BTC", 
    "date": "2022-10-26T03:31:26.343295", 
    "expiry": "2022-10-26T03:46:26.343314", 
    "market": "BTC-NZD", 
    "quote_amount": 3, 
    "quote_amount_dec": "0.03", 
    "quote_asset": "NZD", 
    "quote_fee": 1,             // see here
    "quote_fee_dec": "0.01", 
    "quote_fee_fixed": 100,     // and here
    "quote_fee_fixed_dec": "1", 
    "side": "ask", 
    "status": "created", 
    "token": "R0H4LE73Z4"
  }
}
```