### PR TITLE
added metric_batch_size to 2000 instead of using 1000(default). chagne interval for http input to 60sec from 15sec.

### DIFF
--- a/telegraf/telegraf.conf.j2
+++ b/telegraf/telegraf.conf.j2
@@ -6,6 +6,7 @@
   hostname = "{{ environ('TELEGRAF_NAME') | default('dev') }}"
   flush_interval = "15s"
   interval = "15s"
+  metric_batch_size = 2000
 
 # Input Plugins
 [[inputs.cpu]]
@@ -40,6 +41,7 @@
   data_format = "json"
   timeout = "30s"
   headers = {"HOST" = "{{ environ('SERVER_NAME') }}"}
+  interval = "60s"
 
 # Output Plugin InfluxDB
 [[outputs.influxdb]]


### PR DESCRIPTION
- lower the intervals from 15s to 60s for [input.http]
- increase the metric_batch size from 1000 to 2000