### PR TITLE
downgrading lightningd 0.12.1 to 0.11.1

### DIFF
--- a/lightningd/Dockerfile
+++ b/lightningd/Dockerfile
@@ -1,4 +1,4 @@
-FROM elementsproject/lightningd:v0.12.1
+FROM elementsproject/lightningd:v0.11.1
 
 # we need a staging directory because we cannot modify $LIGHTNINGD_DATA
 # directly as the parent image declares 'VOLUME $LIGHTNINGD_DATA' and


### PR DESCRIPTION
using the following instructions, i was able to downgrade from 0.12.1 to 0.11.1:
```
- stop lightningd
- cp -r /opt/ln_data /opt/ln_data-bak
- delete /opt/ln_data/*
- delete lightningd container
- delete lightningd image
- build image
- start image(just enough to build the files in /opt/ln_data)
- stop lightningd
- cp hsm_secret from ln_data-bak/ file to /opt/ln_data/testnet/ (if we want to use the old hsm_secret)
- build image(might not be needed)
- start lightningd
```